### PR TITLE
Avoid App Store submission failure due to embedded frameworks

### DIFF
--- a/AlamofireObjectMapper.xcodeproj/project.pbxproj
+++ b/AlamofireObjectMapper.xcodeproj/project.pbxproj
@@ -198,7 +198,6 @@
 				6AB2A00C1AF26C36001EBB20 /* Sources */,
 				6AB2A00D1AF26C36001EBB20 /* Frameworks */,
 				6AB2A00E1AF26C36001EBB20 /* Headers */,
-				6A905E411B067F8100884083 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -321,24 +320,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		6A905E411B067F8100884083 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/Alamofire.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/ObjectMapper.framework",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		6AB2A00C1AF26C36001EBB20 /* Sources */ = {


### PR DESCRIPTION
The copy-frameworks build phase embeds the Alamofire and ObjectMapper frameworks within the AlamofireObjectMapper framework - while the configuration works at runtime, it isn't efficient and more importantly, fails App Store submission with errors:
  ERROR ITMS-90205: contains disallowed nested bundles
  ERROR ITMS-90206: contains disallowed file 'Frameworks'

A host application needs to link against and copy the Alamofire and ObjectMapper frameworks anyways, so in addition to passing App Store submission, this change will also reclaim the 5.5 MB (0.9 MB compressed in an IPA) the embedded frameworks would have otherwise taken.