### PR TITLE
Added support for AOM_NO_MODULE option for iOS 7 git submodule integr…

### DIFF
--- a/AlamofireObjectMapper/AlamofireObjectMapper.swift
+++ b/AlamofireObjectMapper/AlamofireObjectMapper.swift
@@ -7,8 +7,10 @@
 //
 
 import Foundation
+#if !AOM_NO_MODULE
 import Alamofire
 import ObjectMapper
+#endif
 
 extension Request {
 	


### PR DESCRIPTION
…ation

Add '-D AOM_NO_MODULE' under Build settings -> Swift Compiler - Custom Flags -> Other Swift Flags

This enables unfortunate users that are stuck on iOS 7 to still use AlamofireObjectManager as a git submodule in their projects.