### PR TITLE
Set iOS deployment target back to 8.0

### DIFF
--- a/AlamofireObjectMapper.xcodeproj/project.pbxproj
+++ b/AlamofireObjectMapper.xcodeproj/project.pbxproj
@@ -478,7 +478,7 @@
 				);
 				INFOPLIST_FILE = AlamofireObjectMapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tristanhimmelman.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AlamofireObjectMapper;
@@ -503,7 +503,7 @@
 				);
 				INFOPLIST_FILE = AlamofireObjectMapper/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tristanhimmelman.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AlamofireObjectMapper;

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Alamofire/Alamofire" == 2.0.0
-github "Hearst-DD/ObjectMapper" == 0.16
+github "Alamofire/Alamofire" ~> 2.0.0
+github "Hearst-DD/ObjectMapper" == 0.17

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Alamofire/Alamofire" "2.0.0"
-github "Hearst-DD/ObjectMapper" "0.16"
+github "Alamofire/Alamofire" "2.0.1"
+github "Hearst-DD/ObjectMapper" "0.17"


### PR DESCRIPTION
In pr #19 the deployment target was changed to `8.3`. I'm assuming that happened by mistake. It won't allow building the framework towards older versions anymore. This pull request reverts the change and sets it again to `8.0`.