### PR TITLE
Added keypath for custom mapping

### DIFF
--- a/AlamofireObjectMapper.xcodeproj/project.pbxproj
+++ b/AlamofireObjectMapper.xcodeproj/project.pbxproj
@@ -587,6 +587,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tristanhimmelman.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos9.0;
 			};
 			name = Debug;
 		};
@@ -602,6 +603,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tristanhimmelman.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos9.0;
 			};
 			name = Release;
 		};

--- a/AlamofireObjectMapper/AlamofireObjectMapper.swift
+++ b/AlamofireObjectMapper/AlamofireObjectMapper.swift
@@ -18,7 +18,7 @@ extension Request {
     /*
     We need to add a stored property for path
     */
-    var path: String? {
+    var keyPath: String? {
         get {
             return objc_getAssociatedObject(self, &xoAssociationKey) as! String?
         }
@@ -66,7 +66,7 @@ extension Request {
 			
 
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-                let parsedObject = Mapper<T>().map(self.path != nil ? result.value?[self.path!] : result.value)
+                let parsedObject = Mapper<T>().map(self.keyPath != nil ? result.value?[self.keyPath!] : result.value)
                 
                 dispatch_async(queue ?? dispatch_get_main_queue()) {
                     completionHandler(self.request!, self.response, parsedObject, result.value ?? result.data, result.error)
@@ -115,7 +115,7 @@ extension Request {
 			
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
                 
-                let parsedObject = Mapper<T>().mapArray(self.path != nil ? result.value?[self.path!] : result.value)
+                let parsedObject = Mapper<T>().mapArray(self.keyPath != nil ? result.value?[self.keyPath!] : result.value)
                 dispatch_async(queue ?? dispatch_get_main_queue()) {
                     completionHandler(self.request!, self.response, parsedObject, result.value ?? result.data, result.error)
                 }

--- a/AlamofireObjectMapper/AlamofireObjectMapper.swift
+++ b/AlamofireObjectMapper/AlamofireObjectMapper.swift
@@ -17,7 +17,7 @@ extension Request {
 	/**
 	Adds a handler to be called once the request has finished.
 	
-	- parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a swift Object. The closure takes 2 arguments: the response object (of type Mappable) and any error produced while making the request
+	- parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a swift Object with support for keypath mapping. The closure takes 2 arguments: the response object (of type Mappable) and any error produced while making the request
 	
 	- returns: The request.
 	*/
@@ -35,9 +35,34 @@ extension Request {
 	
 	- returns: The request.
 	*/
+    public func responseObject<T: Mappable>(completionHandler: (NSURLRequest, NSHTTPURLResponse?, T?, AnyObject?, ErrorType?) -> Void) -> Self {
+        return responseObject(nil, keyPath: nil, completionHandler: completionHandler)
+	}
+    
+    /**
+    Adds a handler to be called once the request has finished.
+    
+    - parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a swift Object. The closure takes 2 arguments: the response object (of type Mappable) and any error produced while making the request
+    
+    - returns: The request.
+    */
+    
+    public func responseObject<T: Mappable>(completionHandler: (T?, ErrorType?) -> Void) -> Self {
+        return responseObject(nil,keyPath: nil) { (request, response, object, data, error) -> Void in
+            completionHandler(object, error)
+        }
+    }
+    
+    /**
+    Adds a handler to be called once the request has finished.
+    
+    - parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a swift Object with support for keypath mapping. The closure takes 5 arguments: the URL request, the URL response, the response object (of type Mappable), the raw response data, and any error produced making the request.
+    
+    - returns: The request.
+    */
     public func responseObject<T: Mappable>(keyPath: String?,completionHandler: (NSURLRequest, NSHTTPURLResponse?, T?, AnyObject?, ErrorType?) -> Void) -> Self {
         return responseObject(nil, keyPath: keyPath, completionHandler: completionHandler)
-	}
+    }
 	
 	/**
 	Adds a handler to be called once the request has finished.
@@ -67,7 +92,7 @@ extension Request {
 	/**
 	Adds a handler to be called once the request has finished.
 	
-	- parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a swift Object. The closure takes 2 arguments: the response array (of type Mappable) and any error produced while making the request
+	- parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a swift Object with support for keypath mapping. The closure takes 2 arguments: the response array (of type Mappable) and any error produced while making the request
 	
 	- returns: The request.
 	*/
@@ -80,13 +105,38 @@ extension Request {
 	/**
 	Adds a handler to be called once the request has finished.
 	
-	- parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a swift Object. The closure takes 5 arguments: the URL request, the URL response, the response array (of type Mappable), the raw response data, and any error produced making the request.
+	- parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a swift Object with support for keypath mapping. The closure takes 5 arguments: the URL request, the URL response, the response array (of type Mappable), the raw response data, and any error produced making the request.
 	
 	- returns: The request.
 	*/
 	public func responseArray<T: Mappable>(keyPath: String?,completionHandler: (NSURLRequest, NSHTTPURLResponse?, [T]?, AnyObject?, ErrorType?) -> Void) -> Self {
         return responseArray(nil,keyPath: keyPath, completionHandler: completionHandler)
 	}
+    
+    /**
+    Adds a handler to be called once the request has finished.
+    
+    - parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a swift Object. The closure takes 2 arguments: the response array (of type Mappable) and any error produced while making the request
+    
+    - returns: The request.
+    */
+    public func responseArray<T: Mappable>(completionHandler: ([T]?, ErrorType?) -> Void) -> Self {
+        return responseArray(nil,keyPath: nil) { (request, response, object, data, error) -> Void in
+            completionHandler(object, error)
+        }
+    }
+    
+    /**
+    Adds a handler to be called once the request has finished.
+    
+    - parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a swift Object. The closure takes 5 arguments: the URL request, the URL response, the response array (of type Mappable), the raw response data, and any error produced making the request.
+    
+    - returns: The request.
+    */
+    public func responseArray<T: Mappable>(completionHandler: (NSURLRequest, NSHTTPURLResponse?, [T]?, AnyObject?, ErrorType?) -> Void) -> Self {
+        return responseArray(nil,keyPath: nil, completionHandler: completionHandler)
+    }
+
 	
 	/**
 	Adds a handler to be called once the request has finished.

--- a/AlamofireObjectMapper/AlamofireObjectMapper.swift
+++ b/AlamofireObjectMapper/AlamofireObjectMapper.swift
@@ -18,7 +18,7 @@ extension Request {
     /*
     We need to add a stored property for path
     */
-    var keyPath: String? {
+    public var keyPath: String? {
         get {
             return objc_getAssociatedObject(self, &xoAssociationKey) as! String?
         }

--- a/AlamofireObjectMapperTests/AlamofireObjectMapperTests.swift
+++ b/AlamofireObjectMapperTests/AlamofireObjectMapperTests.swift
@@ -47,7 +47,8 @@ class AlamofireObjectMapperTests: XCTestCase {
 			XCTAssertNil(error, "\(error)")
 		})
     }
-	
+    
+    
 	func testResponseObject2() {
 		// This is an example of a functional test case.
 		
@@ -117,6 +118,30 @@ class AlamofireObjectMapperTests: XCTestCase {
 			XCTAssertNil(error, "\(error)")
 		})
 	}
+    
+    func testArrayResponseObjectWithKeyPath() {
+        // This is an example of a functional test case.
+        let URL = "https://raw.githubusercontent.com/tristanhimmelman/AlamofireObjectMapper/d8bb95982be8a11a2308e779bb9a9707ebe42ede/sample_json"
+        let expectation = expectationWithDescription("\(URL)")
+        
+        Alamofire.request(.GET, URL, parameters: nil).responseArray ("three_day_forecast", completionHandler: { (request: NSURLRequest, HTTPURLResponse: NSHTTPURLResponse?, response: [Forecast]?, data: AnyObject?, error: ErrorType?) in
+            expectation.fulfill()
+            
+            XCTAssertNotNil(response, "Response should not be nil")
+            
+            for forecast in response! {
+                XCTAssertNotNil(forecast.day, "day should not be nil")
+                XCTAssertNotNil(forecast.conditions, "conditions should not be nil")
+                XCTAssertNotNil(forecast.temperature, "temperature should not be nil")
+            }
+        })
+        
+        waitForExpectationsWithTimeout(10, handler: { (error: NSError?) -> Void in
+            XCTAssertNil(error, "\(error)")
+        })
+    }
+
+
 }
 
 class WeatherResponse: Mappable {


### PR DESCRIPTION
Added keypath property to Response object so you can map custom fields to objects
Example
https://raw.githubusercontent.com/tristanhimmelman/AlamofireObjectMapper/d8bb95982be8a11a2308e779bb9a9707ebe42ede/sample_json

You can specify request.keypath = "three_day_forecast" and map just that