### PR TITLE
Add support for Alamofire Response<T, ErrorType>

### DIFF
--- a/AlamofireObjectMapper/AlamofireObjectMapper.swift
+++ b/AlamofireObjectMapper/AlamofireObjectMapper.swift
@@ -70,6 +70,31 @@ extension Request {
     /**
      Adds a handler to be called once the request has finished.
      
+     - parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a Alamofire Response Object.
+     
+     - returns: The request.
+     */
+    public func responseTestObject<T: Mappable>(completionHandler: (Response<T, NSError>) -> Void) -> Self {
+        return responseObject(nil, keyPath: nil, completionHandler: completionHandler)
+    }
+    
+    
+    /**
+     Adds a handler to be called once the request has finished.
+     
+     - parameter keyPath: The key path where object mapping should be performed
+     - parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a Alamofire Response Object with support for keypath mapping.
+     
+     - returns: The request.
+     */
+    public func responseTestObject<T: Mappable>(keyPath: String?, completionHandler: (Response<T, NSError>) -> Void) -> Self {
+        return responseObject(nil, keyPath: keyPath, completionHandler: completionHandler)
+    }
+    
+    
+    /**
+     Adds a handler to be called once the request has finished.
+     
      - parameter queue: The queue on which the completion handler is dispatched.
      - parameter keyPath: The key path where object mapping should be performed
      - parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a swift Object. The closure takes 5 arguments: the URL request, the URL response, the response object (of type Mappable), the raw response data, and any error produced making the request.
@@ -87,6 +112,39 @@ extension Request {
         
                 dispatch_async(queue ?? dispatch_get_main_queue()) {
                     completionHandler(self.request!, self.response, parsedObject, result.value ?? data, result.error)
+                }
+            }
+        }
+    }
+    
+    
+    /**
+     Adds a handler to be called once the request has finished.
+     
+     - parameter queue: The queue on which the completion handler is dispatched.
+     - parameter keyPath: The key path where object mapping should be performed
+     - parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a Alamofire Response Object.
+     
+     - returns: The request.
+     */
+    public func responseObject<T: Mappable>(queue: dispatch_queue_t?, keyPath: String?, completionHandler:(Response<T, NSError>) -> Void) -> Self {
+        
+        return response(queue: queue) { (request, response, data, error) -> Void in
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+                let JSONResponseSerializer = Request.JSONResponseSerializer(options: .AllowFragments)
+                let result = JSONResponseSerializer.serializeResponse(request, response, data, error)
+                let parsedObject = Mapper<T>().map(keyPath != nil ? result.value?[keyPath!] : result.value)
+                
+                dispatch_async(queue ?? dispatch_get_main_queue()) {
+                    
+                    guard let parsedObject = parsedObject else { return }
+                    guard let error = error else
+                    {
+                        completionHandler(Response(request: request, response: response, data: data, result: Result.Success(parsedObject)))
+                        return
+                    }
+                    
+                    completionHandler(Response(request: request, response: response, data: data, result: Result.Failure(error)))
                 }
             }
         }
@@ -148,7 +206,32 @@ extension Request {
         return responseArray(nil,keyPath: nil, completionHandler: completionHandler)
     }
     
-   
+    
+    /**
+     Adds a handler to be called once the request has finished.
+     
+     - parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a Alamofire Response Object.
+     
+     - returns: The request.
+     */
+    public func responseArray<T: Mappable>(completionHandler: (Response<[T], NSError>) -> Void) -> Self {
+        return responseArray(nil, keyPath: nil, completionHandler: completionHandler)
+    }
+    
+    
+    /**
+     Adds a handler to be called once the request has finished.
+     
+     - parameter keyPath: The key path where object mapping should be performed
+     - parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a Alamofire Response Object with support for keypath mapping.
+     
+     - returns: The request.
+     */
+    public func responseArray<T: Mappable>(keyPath: String?, completionHandler: (Response<[T], NSError>) -> Void) -> Self {
+        return responseArray(nil, keyPath: keyPath, completionHandler: completionHandler)
+    }
+    
+    
     /**
      Adds a handler to be called once the request has finished.
      
@@ -168,6 +251,38 @@ extension Request {
                 
                 dispatch_async(queue ?? dispatch_get_main_queue()) {
                     completionHandler(self.request!, self.response, parsedObject, result.value, result.error)
+                }
+            }
+        }
+    }
+    
+    /**
+     Adds a handler to be called once the request has finished.
+     
+     - parameter queue: The queue on which the completion handler is dispatched.
+     - parameter keyPath: The key path where object mapping should be performed
+     - parameter completionHandler: A closure to be executed once the request has finished and the data has been mapped to a Alamofire Response Object.
+     
+     - returns: The request.
+     */
+    public func responseArray<T: Mappable>(queue: dispatch_queue_t?, keyPath: String?, completionHandler: (Response<[T], NSError>) -> Void) -> Self {
+        
+        return response(queue: queue) { (request, response, data, error) -> Void in
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+                let JSONResponseSerializer = Request.JSONResponseSerializer(options: .AllowFragments)
+                let result = JSONResponseSerializer.serializeResponse(request, response, data, error)
+                let parsedObject = Mapper<T>().mapArray(keyPath != nil ? result.value?[keyPath!] : result.value)
+                
+                dispatch_async(queue ?? dispatch_get_main_queue()) {
+                    
+                    guard let parsedObject = parsedObject else { return }
+                    guard let error = error else
+                    {
+                        completionHandler(Response(request: request, response: response, data: data, result: Result.Success(parsedObject)))
+                        return
+                    }
+                    
+                    completionHandler(Response(request: request, response: response, data: data, result: Result.Failure(error)))
                 }
             }
         }

--- a/AlamofireObjectMapper/AlamofireObjectMapper.swift
+++ b/AlamofireObjectMapper/AlamofireObjectMapper.swift
@@ -74,7 +74,7 @@ extension Request {
      
      - returns: The request.
      */
-    public func responseTestObject<T: Mappable>(completionHandler: (Response<T, NSError>) -> Void) -> Self {
+    public func responseObject<T: Mappable>(completionHandler: (Response<T, NSError>) -> Void) -> Self {
         return responseObject(nil, keyPath: nil, completionHandler: completionHandler)
     }
     
@@ -87,7 +87,7 @@ extension Request {
      
      - returns: The request.
      */
-    public func responseTestObject<T: Mappable>(keyPath: String?, completionHandler: (Response<T, NSError>) -> Void) -> Self {
+    public func responseObject<T: Mappable>(keyPath: String?, completionHandler: (Response<T, NSError>) -> Void) -> Self {
         return responseObject(nil, keyPath: keyPath, completionHandler: completionHandler)
     }
     


### PR DESCRIPTION
`Alamofire.request(API).responseArray({ (response: Response<[AnyObject], NSError>) -> Void in
			switch response.result
            {
            case .Failure(let error):   completion(Result.Failure(error))
            case.Success(let value): completion(Result.Success(value))
            }
        })`