### PR TITLE
use valueForKeyPath for nested dictionaries

### DIFF
--- a/AlamofireObjectMapper/AlamofireObjectMapper.swift
+++ b/AlamofireObjectMapper/AlamofireObjectMapper.swift
@@ -49,7 +49,7 @@ extension Request {
         
             let JSONToMap: AnyObject?
             if let keyPath = keyPath {
-                JSONToMap = result.value?[keyPath]
+                JSONToMap = result.value?.valueForKeyPath(keyPath)
             } else {
                 JSONToMap = result.value
             }


### PR DESCRIPTION
Example:
```
Alamofire.request(.GET, URL).responseObject("response_body.data")
```