### PR TITLE
Allow deserializing the base response object

### DIFF
--- a/AlamofireObjectMapper/AlamofireObjectMapper.swift
+++ b/AlamofireObjectMapper/AlamofireObjectMapper.swift
@@ -83,7 +83,7 @@ extension Request {
      
      - returns: The request.
      */
-    public func responseObject<T: Mappable>(keyPath: String, completionHandler: Response<T, NSError> -> Void) -> Self {
+    public func responseObject<T: Mappable>(keyPath: String?, completionHandler: Response<T, NSError> -> Void) -> Self {
         return responseObject(nil, keyPath: keyPath, completionHandler: completionHandler)
     }
 


### PR DESCRIPTION
Made the `keyPath` optional on line 86 so a base object can be deserialized into an object.