### PR TITLE
Add support for marshalling objects during requests

### DIFF
--- a/AlamofireObjectMapper/AlamofireObjectMapper.swift
+++ b/AlamofireObjectMapper/AlamofireObjectMapper.swift
@@ -30,6 +30,37 @@ import Foundation
 import Alamofire
 import ObjectMapper
 
+/**
+ Creates a request using the specified method, URL string, object, and parameter encoding.
+ 
+ - parameter method:     The HTTP method.
+ - parameter URLString:  The URL string.
+ - parameter object:     The object to be marshalled.
+ - parameter encoding:   The parameter encoding. `.JSON` by default.
+ - parameter headers:    The HTTP headers. `nil` by default.
+ 
+ - returns: The created request.
+ */
+public func request<T: Mappable>(
+    method: Alamofire.Method,
+    _ URLString: URLStringConvertible,
+      object: T? = nil,
+      encoding: ParameterEncoding = .JSON,
+      headers: [String: String]? = nil)
+    -> Request
+{
+    let parameters:[String: AnyObject]? =
+        object != nil ? Mapper().toJSON(object!) : nil
+    
+    return Alamofire.request(
+        method,
+        URLString,
+        parameters: parameters,
+        encoding: encoding,
+        headers: headers
+    )
+}
+
 extension Request {
     
     public static func ObjectMapperSerializer<T: Mappable>(keyPath: String?, mapToObject object: T? = nil) -> ResponseSerializer<T, NSError> {

--- a/AlamofireObjectMapperTests/AlamofireObjectMapperTests.swift
+++ b/AlamofireObjectMapperTests/AlamofireObjectMapperTests.swift
@@ -225,6 +225,43 @@ class AlamofireObjectMapperTests: XCTestCase {
             XCTAssertNil(error, "\(error)")
         }
     }
+    
+    func testPOSTObject() {
+        let URL = "https://example.com/some_endpoint"
+        let inputForecast = Forecast(day: "Friday", temperature: 24, conditions: "Partly cloudy")
+        
+        let httpRequest = request(.POST, URL, object: inputForecast).request!
+        
+        let httpBodyString = NSString(data: httpRequest.HTTPBody!, encoding: NSUTF8StringEncoding)
+        XCTAssertNotNil(httpBodyString, "Request body should not be nil")
+        
+        let outputForecast = Mapper<Forecast>().map(httpBodyString!)!
+
+        XCTAssertEqual(URL, httpRequest.URL?.absoluteString)
+        XCTAssertEqual("application/json", httpRequest.valueForHTTPHeaderField("content-type"))
+        XCTAssertEqual(inputForecast.day, outputForecast.day)
+        XCTAssertEqual(inputForecast.conditions, outputForecast.conditions)
+        XCTAssertEqual(inputForecast.temperature, outputForecast.temperature)
+    }
+    
+    func testPUTObject() {
+        let URL = "https://example.com/some_endpoint"
+        let inputForecast = Forecast(day: "Friday", temperature: 24, conditions: "Partly cloudy")
+        
+        let httpRequest = request(.PUT, URL, object: inputForecast).request!
+        
+        let httpBodyString = NSString(data: httpRequest.HTTPBody!, encoding: NSUTF8StringEncoding)!
+        XCTAssertNotNil(httpBodyString, "Request body should not be nil")
+
+        let outputForecast = Mapper<Forecast>().map(httpBodyString)!
+
+        XCTAssertEqual(URL, httpRequest.URL?.absoluteString)
+        XCTAssertEqual("application/json", httpRequest.valueForHTTPHeaderField("content-type"))
+        XCTAssertEqual(inputForecast.day, outputForecast.day)
+        XCTAssertEqual(inputForecast.conditions, outputForecast.conditions)
+        XCTAssertEqual(inputForecast.temperature, outputForecast.temperature)
+    }
+    
 }
 
 class WeatherResponse: Mappable {
@@ -252,6 +289,12 @@ class Forecast: Mappable {
 	required init?(_ map: Map){
 
 	}
+    
+    init(day: String?, temperature: Int?, conditions: String?) {
+        self.day = day
+        self.temperature = temperature
+        self.conditions = conditions
+    }
 	
 	func mapping(map: Map) { 
 		day <- map["day"]


### PR DESCRIPTION
I didn't see a way to marshal objects into JSON/query params when making requests. I need this feature for the current project I'm working on, so I did my best to get it working.
