### PR TITLE
Upgraded to Alamofire 4.0.0-beta.2

### DIFF
--- a/AlamofireObjectMapper.podspec
+++ b/AlamofireObjectMapper.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
 
   s.requires_arc = 'true'
   s.source_files = 'AlamofireObjectMapper/**/*.swift'
-  s.dependency 'Alamofire', '~> 4.0.0-beta.1'
+  s.dependency 'Alamofire', '~> 4.0-beta'
   s.dependency 'ObjectMapper', '~> 1.0'
 end

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Alamofire/Alamofire" "3ec40fd85a80b451e42ee2c247bcc329cb85cbf5"
+github "Alamofire/Alamofire" "a78137ab4559f37219d6b2825552eea5462e4272"
 github "Hearst-DD/ObjectMapper" "c4affdd91d2049d98109f197e56a814e2773852f"


### PR DESCRIPTION
Updated the podspec to allow the latest running version of the Alamofire 4.0 beta.

This seems advisable, as clients are going to need to hit this moving target as they go for supporting swift 3.