### PR TITLE
use parameter names as is now required by ObjectMapper

### DIFF
--- a/AlamofireObjectMapper/AlamofireObjectMapper.swift
+++ b/AlamofireObjectMapper/AlamofireObjectMapper.swift
@@ -69,9 +69,9 @@ extension DataRequest {
             }
             
             if let object = object {
-                _ = Mapper<T>().map(JSONToMap, toObject: object)
+                _ = Mapper<T>().map(JSONObject: JSONToMap, toObject: object)
                 return .success(object)
-            } else if let parsedObject = Mapper<T>(context: context).map(JSONToMap){
+            } else if let parsedObject = Mapper<T>(context: context).map(JSONObject: JSONToMap){
                 return .success(parsedObject)
             }
 
@@ -118,7 +118,7 @@ extension DataRequest {
                 JSONToMap = result.value
             }
             
-            if let parsedObject = Mapper<T>(context: context).mapArray(JSONToMap){
+            if let parsedObject = Mapper<T>(context: context).mapArray(JSONObject: JSONToMap){
                 return .success(parsedObject)
             }
             


### PR DESCRIPTION
Required by [ObjectMapper's `swift-3` branch](https://github.com/Hearst-DD/ObjectMapper/tree/swift-3), that is.