### PR TITLE
Made compatible with Alamofire 5.0.0-rc2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode10
+osx_image: xcode10.3
 
 env:
   global:

--- a/AlamofireObjectMapper.podspec
+++ b/AlamofireObjectMapper.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.source_files = 'AlamofireObjectMapper/**/*.swift'
-  s.dependency 'Alamofire', '5.0.0-beta.6'
-  s.dependency 'ObjectMapper', '~> 3.4'
+  s.dependency 'Alamofire', '5.0.0-rc.2'
+  s.dependency 'ObjectMapper', '~> 3.5.1'
 end

--- a/AlamofireObjectMapper/AlamofireObjectMapper.swift
+++ b/AlamofireObjectMapper/AlamofireObjectMapper.swift
@@ -129,12 +129,12 @@ extension DataRequest {
      - returns: The request.
      */
     @discardableResult
-    public func responseObject<T: BaseMappable>(queue: DispatchQueue = .main, keyPath: String? = nil, mapToObject object: T? = nil, context: MapContext? = nil, completionHandler: @escaping (DataResponse<T>) -> Void) -> Self {
+    public func responseObject<T: BaseMappable>(queue: DispatchQueue = .main, keyPath: String? = nil, mapToObject object: T? = nil, context: MapContext? = nil, completionHandler: @escaping (AFDataResponse<T>) -> Void) -> Self {
         return response(queue: queue, responseSerializer: DataRequest.ObjectMapperSerializer(keyPath, mapToObject: object, context: context), completionHandler: completionHandler)
     }
     
     @discardableResult
-    public func responseObject<T: ImmutableMappable>(queue: DispatchQueue = .main, keyPath: String? = nil, mapToObject object: T? = nil, context: MapContext? = nil, completionHandler: @escaping (DataResponse<T>) -> Void) -> Self {
+    public func responseObject<T: ImmutableMappable>(queue: DispatchQueue = .main, keyPath: String? = nil, mapToObject object: T? = nil, context: MapContext? = nil, completionHandler: @escaping (AFDataResponse<T>) -> Void) -> Self {
         return response(queue: queue, responseSerializer: DataRequest.ObjectMapperImmutableSerializer(keyPath, context: context), completionHandler: completionHandler)
     }
     
@@ -185,7 +185,7 @@ extension DataRequest {
      - returns: The request.
      */
     @discardableResult
-    public func responseArray<T: BaseMappable>(queue: DispatchQueue = .main, keyPath: String? = nil, context: MapContext? = nil, completionHandler: @escaping (DataResponse<[T]>) -> Void) -> Self {
+    public func responseArray<T: BaseMappable>(queue: DispatchQueue = .main, keyPath: String? = nil, context: MapContext? = nil, completionHandler: @escaping (AFDataResponse<[T]>) -> Void) -> Self {
         return response(queue: queue, responseSerializer: DataRequest.ObjectMapperArraySerializer(keyPath, context: context), completionHandler: completionHandler)
     }
     
@@ -199,7 +199,7 @@ extension DataRequest {
      - returns: The request.
      */
     @discardableResult
-    public func responseArray<T: ImmutableMappable>(queue: DispatchQueue = .main, keyPath: String? = nil, context: MapContext? = nil, completionHandler: @escaping (DataResponse<[T]>) -> Void) -> Self {
+    public func responseArray<T: ImmutableMappable>(queue: DispatchQueue = .main, keyPath: String? = nil, context: MapContext? = nil, completionHandler: @escaping (AFDataResponse<[T]>) -> Void) -> Self {
         return response(queue: queue, responseSerializer: DataRequest.ObjectMapperImmutableArraySerializer(keyPath, context: context), completionHandler: completionHandler)
     }
 }

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Alamofire/Alamofire" "5.0.0-beta.6"
-github "tristanhimmelman/ObjectMapper" ~> 3.4 
+github "Alamofire/Alamofire" "5.0.0-rc.2"
+github "tristanhimmelman/ObjectMapper" ~> 3.5.1 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Alamofire/Alamofire" "5.0.0-beta.6"
+github "Alamofire/Alamofire" "5.0.0-rc.2"
 github "tristanhimmelman/ObjectMapper" "3.5.1"


### PR DESCRIPTION
This PR addresses the following issues:

1. [Alamofire 5.0.0-rc.2 compatible version?](https://github.com/tristanhimmelman/AlamofireObjectMapper/issues/285)
2. [Generic type 'DataResponse' specialized with too few type parameters (got 1, but expected 2)](https://github.com/tristanhimmelman/AlamofireObjectMapper/issues/286)

PTAL @tristanhimmelman 

For those who are using Carthage, you can simply build from here for now:
```
github "ozgur/AlamofireObjectMapper" "master"
```
